### PR TITLE
Updated formula to fix install issues

### DIFF
--- a/Formula/bear_backup.rb
+++ b/Formula/bear_backup.rb
@@ -1,7 +1,7 @@
 class BearBackup < Formula
   desc "Bear backup utility"
   homepage "https://github.com/mivok/bear_backup"
-  head "git@github.com:mivok/bear_backup", :using => :git
+  head "https://github.com/mivok/bear_backup.git", :using => :git
 
   depends_on "python3"
 
@@ -13,7 +13,7 @@ class BearBackup < Formula
   plist_options :manual => "bear_backup"
 
   def plist
-    <<-EOF.undent
+    <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
         "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -44,7 +44,7 @@ class BearBackup < Formula
             </dict>
         </dict>
     </plist>
-    EOF
+    EOS
   end
 
   test do


### PR DESCRIPTION
Hi, I tried to install bear_backup via Homebrew recently and it failed. With a few minor changes, however, I was able to get it to install and run. Great work!

Here's a pull request with a couple of minor changes to the formula file:

* Replaced use of deprecated `EOF.undent` with `EOS`
* The clone operation also now uses HTTPS so that GitHub credentials are not required to download the source

Thanks!