### PR TITLE
Update bear_backup.py with new paths introduced in Bear 1.6

### DIFF
--- a/bear_backup.py
+++ b/bear_backup.py
@@ -12,9 +12,9 @@ import sys
 import zipfile
 
 # Paths to various files
-approot = os.path.expanduser("~/Library/Containers/net.shinyfrog.bear/Data")
-dbpath = os.path.join(approot, "Documents/Application Data/database.sqlite")
-assetpath = os.path.join(approot, "Documents/Application Data/Local Files")
+approot = os.path.expanduser("~/Library/Group Containers/9K33E3U3T4.net.shinyfrog.bear")
+dbpath = os.path.join(approot, "Application Data/database.sqlite")
+assetpath = os.path.join(approot, "Application Data/Local Files")
 imagepath = os.path.join(assetpath, "Note Images")
 filepath = os.path.join(assetpath, "Note Files")
 


### PR DESCRIPTION
Updated paths to reflect Bear 1.6 update.

Source: http://help.shinyfrog.net/discussions/bear/7085-lost-notes-after-time-machine-restore

However, I do receive errors during the backup, not sure why, but I confirmed the backups are functional.

```Traceback (most recent call last):
  File "/usr/local/bin/bear_backup.py", line 171, in <module>
    if note.existing_file_is_newer():
  File "/usr/local/bin/bear_backup.py", line 85, in existing_file_is_newer
    filename = self.full_filename()
  File "/usr/local/bin/bear_backup.py", line 82, in full_filename
    return pathlib.Path(self.filename()).with_suffix(".bearnote")
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/pathlib.py", line 819, in with_suffix
    raise ValueError("%r has an empty name" % (self,))
ValueError: PosixPath('.') has an empty name```